### PR TITLE
feat: Manual conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "biro",
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -28,7 +28,7 @@
           );
           const data = response.data.data;
 
-          rates.set(data[$ownerData.issue_date]);
+          rates.set(data);
         }
       }).catch(error => {
         console.error(error);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,13 +1,13 @@
 export const fetchRates = async (date, currency) => {
   const response = await fetch(
     // fetch just one day
-    `https://freecurrencyapi.net/api/v2/historical?${
-      CURRENCY_EXCHANGE_API_KEY !== ""
+    `https://api.freecurrencyapi.com/v1/latest?${
+      CURRENCY_EXCHANGE_API_KEY !== ''
         ? `apikey=${CURRENCY_EXCHANGE_API_KEY}`
-        : ""
-    }&base_currency=${currency}&date_from=${date}&date_to=${date}`,
+        : ''
+    }&base_currency=${currency}`,
     {
-      method: "GET",
+      method: 'GET',
     }
   );
 

--- a/src/components/exporter/Exporter.svelte
+++ b/src/components/exporter/Exporter.svelte
@@ -1,7 +1,7 @@
 <script>
   import pdfMake from "pdfmake/build/pdfmake";
   import { format } from "date-fns";
-  import { invoiceItems, rates, clientData, ownerData } from "store";
+  import { invoiceItems, rates, clientData, ownerData, manualConversion } from "store";
   import { pdfMakeFont } from "constants";
   import { pdfMakeInvoiceDefinition } from "./pdfmake-definitions";
   import { calculateTotalPrice, calculateTotalVAT } from "utils";
@@ -24,7 +24,8 @@
           invoiceItems: $invoiceItems,
           rates: $rates,
           clientData: $clientData,
-          ownerData: $ownerData
+          ownerData: $ownerData,
+          manualConversion: $manualConversion,
         })
       )
       .download(

--- a/src/components/exporter/pdfmake-definitions.js
+++ b/src/components/exporter/pdfmake-definitions.js
@@ -141,6 +141,7 @@ const generateInvoice = ({
   clientData,
   ownerData,
   rates,
+  manualConversion,
 }) => {
   const invoice = [];
 
@@ -251,7 +252,18 @@ const generateInvoice = ({
     },
   });
 
-  if (ownerData.use_conversion) {
+  if (manualConversion.enabled) {
+    invoice.push({
+      text: `Exchange rate for ${manualConversion.baseCurrency} / ${manualConversion.conversionCurrency} on the day ${format(
+        new Date(ownerData.issue_date),
+        "d.M.yyyy"
+      )}: ${manualConversion.rate}`,
+
+      margin: [0, 30, 0, 5],
+    });
+  }
+
+  if (ownerData.use_conversion && !manualConversion.enabled) {
     invoice.push({
       text: `Exchange rate for the USD / EUR on the day ${format(
         new Date(ownerData.issue_date),
@@ -347,6 +359,7 @@ export const pdfMakeInvoiceDefinition = ({
   clientData,
   ownerData,
   rates,
+  manualConversion,
 }) => {
   return {
     content: generateInvoice({
@@ -358,6 +371,7 @@ export const pdfMakeInvoiceDefinition = ({
       clientData,
       ownerData,
       rates,
+      manualConversion,
     }),
     styles: {
       metaCell: {

--- a/src/components/forms/InvoiceTemplateSetupForm.svelte
+++ b/src/components/forms/InvoiceTemplateSetupForm.svelte
@@ -253,7 +253,7 @@
             const response = await fetchRates($ownerData.issue_date, $ownerData.base_currency);
             const data = response.data.data;
 
-            rates.set(data[$ownerData.issue_date]);            
+            rates.set(data);            
           }
         }} />
       Use conversion

--- a/src/components/forms/InvoiceTemplateSetupForm.svelte
+++ b/src/components/forms/InvoiceTemplateSetupForm.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { ownerData, rates } from "store";
+  import { ownerData, rates, manualConversion } from "store";
   import { idbRead, idbUpdate } from "utils";
   import { fetchRates } from "api";
   import { LOCALES } from "constants";
@@ -51,6 +51,12 @@
 
   .button.remove {
     margin-top: 5px;
+  }
+
+  .manual-conversion {
+    width: 100%;
+    display: flex;
+    gap: 8px;
   }
 </style>
 
@@ -269,4 +275,57 @@
       I am VAT free
     </label>
   </div>
+
+  <div class="field">
+    <label>
+      <input
+        type="checkbox"
+        bind:checked={$manualConversion.enabled}
+      />
+      Use manual conversion
+    </label>
+  </div>
+
+  {#if $manualConversion.enabled}
+    <div class="manual-conversion">
+      <div class="g-r-c g-r-c-25">
+        <div class="field">
+          <label for="manualBaseCurrency">Base currency</label>
+          <select
+            id="manualBaseCurrency"
+            bind:value={$manualConversion.baseCurrency}
+            on:blur={async () => {
+              handleInputChange();
+            }}>
+            {#each Object.keys(LOCALES) as currency, index}
+              <option value={currency}>{currency}</option>
+            {/each}
+          </select>
+        </div>
+      </div>
+      <div class="g-r-c g-r-c-25">
+        <div class="field">
+          <label for="manualConversionCurrency">Conversion currency</label>
+          <select
+            id="manualConversionCurrency"
+            bind:value={$manualConversion.conversionCurrency}
+            on:blur={async () => {
+              handleInputChange();
+            }}>
+            {#each Object.keys(LOCALES) as currency, index}
+              <option value={currency}>{currency}</option>
+            {/each}
+          </select>
+        </div>
+      </div>
+      <div class="field">
+        <label for="manualConversionValue">Rate:</label>
+        <input
+          id="manualConversionValue"
+          type="text"
+          bind:value={$manualConversion.rate}
+          placeholder="Conversion rate" />
+      </div>
+    </div>
+  {/if}
 </form>

--- a/src/components/forms/IssueDateForm.svelte
+++ b/src/components/forms/IssueDateForm.svelte
@@ -20,7 +20,7 @@
             );
             const data = response.data.data;
 
-            rates.set(data[$ownerData.issue_date]);
+            rates.set(data);
           }
         });
     }, 500);

--- a/src/components/invoice/InvoiceFooter.svelte
+++ b/src/components/invoice/InvoiceFooter.svelte
@@ -22,7 +22,7 @@
 {#if Object.entries($rates).length > 0 && $ownerData.use_conversion}
   <p class="rate">
     Exchange rate for the {$ownerData.base_currency} / {$ownerData.foreign_currency}
-    on the day {format(new Date($ownerData.issue_date), 'd.M.yyyy')}:
+    on the day {format(new Date(), 'd.M.yyyy')}:
     <strong>{$rates[$ownerData.foreign_currency].toFixed(4)}</strong>
     <br />
     <small>

--- a/src/components/invoice/InvoiceFooter.svelte
+++ b/src/components/invoice/InvoiceFooter.svelte
@@ -1,6 +1,6 @@
 <script>
   import { format } from "date-fns";
-  import { rates, ownerData } from "store";
+  import { rates, ownerData, manualConversion } from "store";
 </script>
 
 <style>
@@ -19,10 +19,10 @@
   }
 </style>
 
-{#if Object.entries($rates).length > 0 && $ownerData.use_conversion}
+{#if Object.entries($rates).length > 0 && $ownerData.use_conversion && !$manualConversion.enabled}
   <p class="rate">
     Exchange rate for the {$ownerData.base_currency} / {$ownerData.foreign_currency}
-    on the day {format(new Date(), 'd.M.yyyy')}:
+    on the day {format(new Date($ownerData.issue_date), 'd.M.yyyy')}:
     <strong>{$rates[$ownerData.foreign_currency].toFixed(4)}</strong>
     <br />
     <small>
@@ -32,6 +32,14 @@
         https://freecurrencyapi.net
       </a>
     </small>
+  </p>
+{/if}
+
+{#if $manualConversion.enabled}
+  <p class="rate">
+    Exchange rate for {$manualConversion.baseCurrency} / {$manualConversion.conversionCurrency}
+    on the day {format(new Date($ownerData.issue_date), 'd.M.yyyy')}:
+    <strong>{$manualConversion.rate}</strong>
   </p>
 {/if}
 {#if $ownerData.is_vat_free}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -90,3 +90,10 @@ export const shownPropertiesCount = derived(
   ($properties) =>
     Object.values($properties).filter((property) => property.show).length
 );
+
+export const manualConversion = writable({
+  enabled: false,
+  baseCurrency: "EUR",
+  conversionCurrency: "USD",
+  rate: 1,
+});


### PR DESCRIPTION
Fixed automatic conversion to the new API standards (but can only be done for today due to us not being able to fetch historical data for the current day)

Added a `Use manual conversion` checkbox, which enables you to write your own conversion for the invoice.